### PR TITLE
Fixed read/write issue for certain locales.

### DIFF
--- a/JSONModel/JSONModelTransformations/JSONValueTransformer.m
+++ b/JSONModel/JSONModelTransformations/JSONValueTransformer.m
@@ -217,7 +217,8 @@ static NSDateFormatter *_dateFormatter;
     static NSDateFormatter* dateFormatter;
     dispatch_once(&once, ^{
         dateFormatter = [[NSDateFormatter alloc] init];
-        [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HHmmssZZZZ"];
+        [dateFormatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
+        [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HHmmssZZZ"];
     });
     return dateFormatter;
 }
@@ -231,6 +232,7 @@ static NSDateFormatter *_dateFormatter;
 -(NSString*)__JSONObjectFromNSDate:(NSDate*)date
 {
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
     [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZ"];
     return [dateFormatter stringFromDate:date];
 }


### PR DESCRIPTION
I've confirmed the fix with users.

In certain locales, or perhaps for people that travel, saving and loading is inconsistent and loads as either nil or 01-01-2001. 

If a locale isn't specified on the save, I believe iOS uses whatever locale is currently set. If that changes, this can cause problems.

The locale needs to be forced on read and write to have data consistency.