### PR TITLE
Bring back fast enumeration to JSONModelArray

### DIFF
--- a/JSONModel/JSONModel/JSONModelArray.h
+++ b/JSONModel/JSONModel/JSONModelArray.h
@@ -27,7 +27,7 @@
  * of each of the objects stored in the array, it'll be converted to the target model class.
  * Thus saving time upon the very first model creation.
  */
-@interface JSONModelArray : NSObject
+@interface JSONModelArray : NSObject <NSFastEnumeration>
 
 /**
  * Don't make instances of JSONModelArray yourself, except you know what you are doing.

--- a/JSONModel/JSONModel/JSONModelArray.m
+++ b/JSONModel/JSONModel/JSONModelArray.m
@@ -23,7 +23,7 @@
     Class _targetClass;
 }
 
-- (id)initWithArray:(NSArray *)array modelClass:(Class)cls
+-(id)initWithArray:(NSArray *)array modelClass:(Class)cls
 {
     self = [super init];
     
@@ -34,22 +34,22 @@
     return self;
 }
 
-- (id)firstObject
+-(id)firstObject
 {
     return [self objectAtIndex:0];
 }
 
-- (id)lastObject
+-(id)lastObject
 {
     return [self objectAtIndex:_storage.count - 1];
 }
 
-- (id)objectAtIndex:(NSUInteger)index
+-(id)objectAtIndex:(NSUInteger)index
 {
 	return [self objectAtIndexedSubscript:index];
 }
 
-- (id)objectAtIndexedSubscript:(NSUInteger)index
+-(id)objectAtIndexedSubscript:(NSUInteger)index
 {
     id object = _storage[index];
     if (![object isMemberOfClass:_targetClass]) {
@@ -62,7 +62,7 @@
     return object;
 }
 
-- (void)forwardInvocation:(NSInvocation *)anInvocation
+-(void)forwardInvocation:(NSInvocation *)anInvocation
 {
     [anInvocation invokeWithTarget:_storage];
 }
@@ -70,14 +70,14 @@
 -(id)forwardingTargetForSelector:(SEL)selector
 {
     static NSArray* overridenMethods = nil;
-    if (!overridenMethods) overridenMethods = @[@"initWithArray:modelClass:",@"objectAtIndex:",@"objectAtIndexedSubscript:", @"count",@"modelWithIndexValue:",@"description",@"mutableCopy",@"firstObject",@"lastObject"];
+    if (!overridenMethods) overridenMethods = @[@"initWithArray:modelClass:",@"objectAtIndex:",@"objectAtIndexedSubscript:", @"count",@"modelWithIndexValue:",@"description",@"mutableCopy",@"firstObject",@"lastObject",@"countByEnumeratingWithState:objects:count:"];
     if ([overridenMethods containsObject:NSStringFromSelector(selector)]) {
         return self;
     }
     return _storage;
 }
 
-- (NSUInteger)count
+-(NSUInteger)count
 {
     return _storage.count;
 }
@@ -112,6 +112,34 @@
     }
     [res appendFormat:@"\n</JSONModelArray>"];
     return res;
+}
+
+-(NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state
+								 objects:(id __unsafe_unretained [])stackbuf
+								   count:(NSUInteger)stackbufLength
+{
+    NSUInteger count = 0;
+    
+    unsigned long countOfItemsAlreadyEnumerated = state->state;
+    
+    if (countOfItemsAlreadyEnumerated == 0) {
+        state->mutationsPtr = &state->extra[0];
+    }
+	
+    if (countOfItemsAlreadyEnumerated < [self count]) {
+        state->itemsPtr = stackbuf;
+        while ((countOfItemsAlreadyEnumerated < [self count]) && (count < stackbufLength)) {
+            stackbuf[count] = [self objectAtIndex:countOfItemsAlreadyEnumerated];
+            countOfItemsAlreadyEnumerated++;
+            count++;
+        }
+    } else {
+        count = 0;
+    }
+	
+    state->state = countOfItemsAlreadyEnumerated;
+    
+    return count;
 }
 
 @end

--- a/JSONModelDemoTests/UnitTests/ArrayTests.m
+++ b/JSONModelDemoTests/UnitTests/ArrayTests.m
@@ -38,12 +38,19 @@
     XCTAssertEqualObjects([[repos.repositories[0] class] description], @"GitHubRepoModel", @".properties[0] is not a GitHubRepoModel");
 }
 
-- (void)testCount
+-(void)testCount
 {
     XCTAssertEqualObjects(@(repos.repositories.count), @100, @"wrong count");
 }
 
-- (void)testReadArray
+-(void)testFastEnumeration
+{
+	for (GitHubRepoModel *m in repos.repositories) {
+		XCTAssertNoThrow([m created], @"should not throw exception");
+	}
+}
+
+-(void)testReadArray
 {
 	JSONModelArray *array = [JSONModelArray new];
 


### PR DESCRIPTION
Bring back fast enumeration to JSONModelArray, lost in commit c4ffee63b64a71c1319b6b5149f60ee88c5f92b8. Based on a [sample from Apple](https://developer.apple.com/library/mac/samplecode/FastEnumerationSample/Introduction/Intro.html#//apple_ref/doc/uid/DTS40009411-Intro-DontLinkElementID_2).