### PR TITLE
Store property type information from most specific class instead of most generic class

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -347,7 +347,9 @@ static JSONKeyMapper* globalKeyMapper = nil;
             if (property.type == nil && property.structName==nil) {
                 
                 //generic setter
-                [self setValue:jsonValue forKey: property.name];
+                if (jsonValue != [self valueForKey:property.name]) {
+                    [self setValue:jsonValue forKey: property.name];
+                }
                 
                 //skip directly to the next key
                 continue;
@@ -355,7 +357,9 @@ static JSONKeyMapper* globalKeyMapper = nil;
             
             // 0.5) handle nils
             if (isNull(jsonValue)) {
-                [self setValue:nil forKey: property.name];
+                if ([self valueForKey:property.name] != nil) {
+                    [self setValue:nil forKey: property.name];
+                }
                 continue;
             }
             
@@ -378,7 +382,9 @@ static JSONKeyMapper* globalKeyMapper = nil;
 					}
                     return NO;
                 }
-                [self setValue:value forKey: property.name];
+                if (![value isEqual:[self valueForKey:property.name]]) {
+                    [self setValue:value forKey: property.name];
+                }
                 
                 //for clarity, does the same without continue
                 continue;
@@ -410,7 +416,9 @@ static JSONKeyMapper* globalKeyMapper = nil;
                     }
                     
                     //set the property value
-                    [self setValue:jsonValue forKey: property.name];
+                    if (![jsonValue isEqual:[self valueForKey:property.name]]) {
+                        [self setValue:jsonValue forKey: property.name];
+                    }
                     continue;
                 }
                 
@@ -460,7 +468,9 @@ static JSONKeyMapper* globalKeyMapper = nil;
                         jsonValue = [valueTransformer performSelector:selector withObject:jsonValue];
 #pragma clang diagnostic pop
                         
-                        [self setValue:jsonValue forKey: property.name];
+                        if (![jsonValue isEqual:[self valueForKey:property.name]]) {
+                            [self setValue:jsonValue forKey: property.name];
+                        }
                         
                     } else {
                         
@@ -474,7 +484,9 @@ static JSONKeyMapper* globalKeyMapper = nil;
                     
                 } else {
                     // 3.4) handle "all other" cases (if any)
-                    [self setValue:jsonValue forKey: property.name];
+                    if (![jsonValue isEqual:[self valueForKey:property.name]]) {
+                        [self setValue:jsonValue forKey: property.name];
+                    }
                 }
             }
         }

--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -670,7 +670,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
             }
             
             //add the property object to the temp index
-            if (p) {
+            if (p && ![propertyIndex objectForKey:p.name]) {
                 [propertyIndex setValue:p forKey:p.name];
             }
         }


### PR DESCRIPTION
Consider an example model:

```objc
@interface MyRootObject : JSONModel
@property (strong, nonatomic) MyRootMetadata* metadata;
@end

@interface MySpecificObject : MyRootObject
@property (strong, nonatomic) MySpecificMetadata* metadata;
@end
```

And the metadata classes look like:

```objc
@interface MyRootMetadata : JSONModel
// ...
@end

@interface MySpecificMetadata: MyRootMetadata
// ...
@end
```

Essentially `MySpecificObject` has overridden its `metadata` property to be of a more specific class type. The JSONModel parser prefers to get property name/information from the most root class, rather than the most specific class.

This fix gives priority to the specific class over the root class.