### PR TITLE
Fix bug in modifying the shared requiredPropertyNames of a JSONModel

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -211,7 +211,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
 {
     //check if all required properties are present
     NSArray* incomingKeysArray = [dict allKeys];
-    NSMutableSet* requiredProperties = [self __requiredPropertyNames];
+    NSMutableSet* requiredProperties = [self __requiredPropertyNames].mutableCopy;
     NSSet* incomingKeys = [NSSet setWithArray: incomingKeysArray];
     
     //transform the key names, if neccessary


### PR DESCRIPTION
The requiredPropertyNames are stored as an associated object on the class, but during initialization that mutable set can be modified.
This change creates a mutableCopy of the requiredProperties, which allows concurrent changes to the requiredProperties.