### PR TITLE
Safer transformation of NSURLFromNSString

### DIFF
--- a/JSONModel/JSONModelTransformations/JSONValueTransformer.m
+++ b/JSONModel/JSONModelTransformations/JSONValueTransformer.m
@@ -202,7 +202,7 @@ static NSDateFormatter *_dateFormatter;
 #pragma mark - string <-> url
 -(NSURL*)NSURLFromNSString:(NSString*)string
 {
-    return [NSURL URLWithString:string];
+    return [NSURL URLWithString:[string stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
 }
 
 -(NSString*)JSONObjectFromNSURL:(NSURL*)url


### PR DESCRIPTION
e.g. this will handle white spaces in string (convert to %20) instead of returning a nil object.