### PR TITLE
Add error log in initWithCoder.

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -1277,7 +1277,9 @@ static JSONKeyMapper* globalKeyMapper = nil;
 {
     NSString* json = [decoder decodeObjectForKey:@"json"];
     
-    self = [self initWithString:json error:nil];
+    JSONModelError *error = nil;
+    self = [self initWithString:json error:&error];
+    if(error) JMLog(@"%@",[error localizedDescription]);
     return self;
 }
 


### PR DESCRIPTION
Add error log in initWithCoder.

When I use [NSKeyedArchiver archiveRootObject] selector to serialize my model which is subclass of JSONModel,it is ok.But When I use [NSKeyedUnarchiver unarchiveObjectWithFile] to unserialize it,it just don't work and It makes me some time to figure out the property must be optional if it can be nil because there is no any log.