### PR TITLE
Use asynchronous network calls, remove unused etag, fix error override

### DIFF
--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.m
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.m
@@ -105,7 +105,7 @@ static NSString* requestContentType = nil;
                                       [requestString substringToIndex:1],
                                       [requestString substringFromIndex: requestString.length -1]
                                       ];
-        
+
         if ([firstAndLastChar isEqualToString:@"{}"] || [firstAndLastChar isEqualToString:@"[]"]) {
             //guessing for a JSON request
             contentType = kContentTypeJSON;
@@ -126,9 +126,9 @@ static NSString* requestContentType = nil;
     if ([value isKindOfClass:[NSNumber class]]) {
         value = [(NSNumber*)value stringValue];
     }
-    
+
     NSAssert([value isKindOfClass:[NSString class]], @"request parameters can be only of NSString or NSNumber classes. '%@' is of class %@.", value, [value class]);
-        
+
     return (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(
                                                                                  NULL,
                                                                                  (__bridge CFStringRef) value,
@@ -138,7 +138,7 @@ static NSString* requestContentType = nil;
 }
 
 #pragma mark - networking worker methods
-+(NSData*)syncRequestDataFromURL:(NSURL*)url method:(NSString*)method requestBody:(NSData*)bodyData headers:(NSDictionary*)headers etag:(NSString**)etag error:(JSONModelError**)err
++(void)asyncRequestDataFromURL:(NSURL*)url method:(NSString*)method requestBody:(NSData*)bodyData headers:(NSDictionary*)headers completion:(void (^)(NSURLResponse* response, NSData* data, JSONModelError* connectionError)) completion
 {
     //turn on network indicator
     if (doesControlIndicator) dispatch_async(dispatch_get_main_queue(), ^{[self setNetworkIndicatorVisible:YES];});
@@ -158,60 +158,57 @@ static NSString* requestContentType = nil;
         //user set content type
         [request setValue: requestContentType forHTTPHeaderField:@"Content-type"];
     }
-    
+
     //add all the custom headers defined
     for (NSString* key in [requestHeaders allKeys]) {
         [request setValue:requestHeaders[key] forHTTPHeaderField:key];
     }
-    
+
     //add the custom headers
     for (NSString* key in [headers allKeys]) {
         [request setValue:headers[key] forHTTPHeaderField:key];
     }
-    
+
     if (bodyData) {
         [request setHTTPBody: bodyData];
         [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)bodyData.length] forHTTPHeaderField:@"Content-Length"];
     }
-    
-    //prepare output
-	NSHTTPURLResponse* response = nil;
-    
-    //fire the request
-	NSData *responseData = [NSURLConnection sendSynchronousRequest: request
-                                                 returningResponse: &response
-                                                             error: err];
-    //convert an NSError to a JSONModelError
-    if (*err != nil) {
-        NSError* errObj = *err;
-        *err = [JSONModelError errorWithDomain:errObj.domain code:errObj.code userInfo:errObj.userInfo];
-    }
-    
-    //turn off network indicator
-    if (doesControlIndicator) dispatch_async(dispatch_get_main_queue(), ^{[self setNetworkIndicatorVisible:NO];});
-    
-    //if not OK status set the err to a JSONModelError instance
-	if (response.statusCode >= 300 || response.statusCode < 200) {
-        //create a new error
-        if (*err==nil) *err = [JSONModelError errorBadResponse];
-    }
-    
-    //if there was an error, include the HTTP response and return
-    if (*err) {
-        //assign the response to the JSONModel instance
-        [*err setHttpResponse: [response copy]];
 
-        //empty respone, return nil instead
-        if ([responseData length]<1) {
-            return nil;
+    [NSURLConnection sendAsynchronousRequest:request queue:[NSOperationQueue new] completionHandler:^(NSURLResponse* resp, NSData* responseData, NSError* err) {
+
+        NSHTTPURLResponse *response = (NSHTTPURLResponse *)resp;
+
+        JSONModelError* jmErr = nil;
+
+        //convert an NSError to a JSONModelError
+        if (err != nil) {
+            jmErr = [JSONModelError errorWithDomain:err.domain code:err.code userInfo:err.userInfo];
         }
-    }
-    
-    //return the data fetched from web
-    return responseData;
+
+        //turn off network indicator
+        if (doesControlIndicator) dispatch_async(dispatch_get_main_queue(), ^{[self setNetworkIndicatorVisible:NO];});
+
+        //if not OK status set the err to a JSONModelError instance
+        if (response.statusCode >= 300 || response.statusCode < 200) {
+            //create a new error
+            if (jmErr==nil) jmErr = [JSONModelError errorBadResponse];
+        }
+
+        //if there was an error, include the HTTP response and return
+        if (jmErr) {
+            //assign the response to the JSONModel instance
+            [jmErr setHttpResponse:[response copy]];
+
+            if ([responseData length]<1) {
+                responseData = nil;
+            }
+        }
+
+        completion(resp, responseData, jmErr);
+    }];
 }
 
-+(NSData*)syncRequestDataFromURL:(NSURL*)url method:(NSString*)method params:(NSDictionary*)params headers:(NSDictionary*)headers etag:(NSString**)etag error:(JSONModelError**)err
++(void)asyncRequestDataFromURL:(NSURL*)url method:(NSString*)method params:(NSDictionary*)params headers:(NSDictionary*)headers completion:(void (^)(NSURLResponse* response, NSData* data, JSONModelError* connectionError)) completion
 {
     //create the request body
     NSMutableString* paramsString = nil;
@@ -226,7 +223,7 @@ static NSString* requestContentType = nil;
             paramsString = [[NSMutableString alloc] initWithString: [paramsString substringToIndex: paramsString.length-1]];
         }
     }
-    
+
     //set the request params
     if ([method isEqualToString:kHTTPMethodGET] && params) {
 
@@ -237,14 +234,13 @@ static NSString* requestContentType = nil;
                                     paramsString
                                     ]];
     }
-    
-    //call the more general synq request method
-    return [self syncRequestDataFromURL: url
-                                 method: method
-                            requestBody: [method isEqualToString:kHTTPMethodPOST]?[paramsString dataUsingEncoding:NSUTF8StringEncoding]:nil
-                                headers: headers
-                                   etag: etag
-                                  error: err];
+
+    //call the more general sync request method.
+    [self asyncRequestDataFromURL:url
+                           method:method
+                      requestBody:[method isEqualToString:kHTTPMethodPOST] ? [paramsString dataUsingEncoding:NSUTF8StringEncoding] : nil
+                          headers:headers
+                       completion:completion];
 }
 
 #pragma mark - Async network request
@@ -270,65 +266,54 @@ static NSString* requestContentType = nil;
 
 +(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary *)params orBodyData:(NSData*)bodyData headers:(NSDictionary*)headers completion:(JSONObjectBlock)completeBlock
 {
-    NSDictionary* customHeaders = headers;
+    void (^completion)(NSURLResponse*, NSData*, JSONModelError*) = ^(NSURLResponse* response, NSData* responseData, JSONModelError* error) {
 
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        
-        id jsonObject = nil;
-        JSONModelError* error = nil;
-        NSData* responseData = nil;
-        NSString* etag = nil;
-        
-        @try {
-            if (bodyData) {
-                responseData = [self syncRequestDataFromURL: [NSURL URLWithString:urlString]
-                                                     method: method
-                                                requestBody: bodyData
-                                                    headers: customHeaders
-                                                       etag: &etag
-                                                      error: &error];
-            } else {
-                responseData = [self syncRequestDataFromURL: [NSURL URLWithString:urlString]
-                                                     method: method
-                                                     params: params
-                                                    headers: customHeaders
-                                                       etag: &etag
-                                                      error: &error];
-            }
-        }
-        @catch (NSException *exception) {
-            error = [JSONModelError errorBadResponse];
-        }
-        
-        //step 3: if there's no response so far, return a basic error
-        if (!responseData && !jsonObject) {
+        //step 3: if there's no response or error so far, return a basic error
+        if (!responseData && !error) {
             //check for false response, but no network error
             error = [JSONModelError errorBadResponse];
         }
 
+        id jsonObject = nil;
+
         //step 4: if there's a response at this and no errors, convert to object
-        if (error==nil && jsonObject==nil) {
-			// Note: it is possible to have a valid response with empty response data (204 No Content).
-			// So only create the JSON object if there is some response data.
-			if(responseData.length > 0)
-			{
-				//convert to an object
-				jsonObject = [NSJSONSerialization JSONObjectWithData:responseData options:kNilOptions error:&error];
-			}
+        if (error==nil) {
+            // Note: it is possible to have a valid response with empty response data (204 No Content).
+            // So only create the JSON object if there is some response data.
+            if(responseData.length > 0)
+            {
+                //convert to an object
+                jsonObject = [NSJSONSerialization JSONObjectWithData:responseData options:kNilOptions error:&error];
+            }
         }
         //step 4.5: cover an edge case in which meaningful content is return along an error HTTP status code
-        else if (error && responseData && jsonObject==nil) {
-            //try to get the JSON object, while preserving the origianl error object
+        else if (responseData) {
+            //try to get the JSON object, while preserving the original error object
             jsonObject = [NSJSONSerialization JSONObjectWithData:responseData options:kNilOptions error:nil];
         }
-        
+
         //step 5: invoke the complete block
         dispatch_async(dispatch_get_main_queue(), ^{
             if (completeBlock) {
                 completeBlock(jsonObject, error);
             }
         });
-    });
+
+    };
+
+    if (bodyData) {
+        [self asyncRequestDataFromURL:[NSURL URLWithString:urlString]
+                               method:method
+                          requestBody:bodyData
+                              headers:headers
+                           completion:completion];
+    } else {
+        [self asyncRequestDataFromURL:[NSURL URLWithString:urlString]
+                               method:method
+                               params:params
+                              headers:headers
+                           completion:completion];
+    }
 }
 
 #pragma mark - request aliases


### PR DESCRIPTION
Uses `NSURLConnection`'s `sendAsynchronousRequest` instead of `sendSynchronousRequest`.

Also removes unused argument `etag` and fixes error override explained here: https://github.com/icanzilb/JSONModel/issues/313.