### PR TITLE
Make built-in JSONKeyMappers more extensible

### DIFF
--- a/JSONModel/JSONModelTransformations/JSONKeyMapper.h
+++ b/JSONModel/JSONModelTransformations/JSONKeyMapper.h
@@ -92,4 +92,11 @@ typedef NSString* (^JSONModelKeyMapBlock)(NSString* keyName);
 +(instancetype)mapperFromUnderscoreCaseToCamelCase;
 
 +(instancetype)mapperFromUpperCaseToLowerCase;
+
+/**
+ * Creates a JSONKeyMapper based on a built-in JSONKeyMapper, with specific exceptions.
+ * Use the original JSON key names as keys, and your JSONModel property names as values.
+ */
++ (instancetype)mapper:(JSONKeyMapper *)baseKeyMapper
+        withExceptions:(NSDictionary *)exceptions;
 @end

--- a/JSONModel/JSONModelTransformations/JSONKeyMapper.m
+++ b/JSONModel/JSONModelTransformations/JSONKeyMapper.m
@@ -171,4 +171,45 @@
 
 }
 
++ (instancetype)mapper:(JSONKeyMapper *)baseKeyMapper
+        withExceptions:(NSDictionary *)exceptions
+{
+    NSDictionary* userToModelMap = [exceptions copy];
+    NSDictionary* userToJSONMap  = [NSDictionary dictionaryWithObjects:exceptions.allKeys forKeys:exceptions.allValues];
+    
+    JSONModelKeyMapBlock JSONtoModel = ^NSString *(NSString* keyName) {
+        if ( !keyName )
+        {
+            return nil;
+        }
+        else if ( userToModelMap[keyName] )
+        {
+            return userToModelMap[keyName];
+        }
+        else
+        {
+            return baseKeyMapper.JSONToModelKeyBlock(keyName);
+        }
+    };
+    
+    JSONModelKeyMapBlock ModeltoJSON = ^NSString *(NSString* keyName) {
+        if ( !keyName )
+        {
+            return nil;
+        }
+        else if ( userToJSONMap[keyName] )
+        {
+            return userToJSONMap[keyName];
+        }
+        else
+        {
+            return baseKeyMapper.modelToJSONKeyBlock(keyName);
+        }
+    };
+    
+    return [[self alloc] initWithJSONToModelBlock:JSONtoModel
+                                 modelToJSONBlock:ModeltoJSON];
+    
+}
+
 @end

--- a/JSONModelDemoTests/UnitTests/KeyMappingTests.m
+++ b/JSONModelDemoTests/UnitTests/KeyMappingTests.m
@@ -9,6 +9,7 @@
 #import "KeyMappingTests.h"
 #import "JSONModelLib.h"
 #import "GitHubKeyMapRepoModel.h"
+#import "RenamedPropertyModel.h"
 #import "GitHubKeyMapRepoModelDict.h"
 #import "GitHubRepoModelForUSMapper.h"
 #import "ModelForUpperCaseMapper.h"
@@ -144,6 +145,24 @@
     XCTAssertNotNil(dict, @"toDictionary failed");
 
     XCTAssertEqualObjects(dict[@"UPPERTEST"], m.uppertest, @"UPPERTEST does not equal 'TEST'");
+}
+
+-(void)testExceptionsMapper
+{
+    NSString* jsonString = @"{\"ID\":\"12345\",\"NAME\":\"TEST\"}";
+    RenamedPropertyModel* m = [[RenamedPropertyModel alloc] initWithString:jsonString error:nil];
+    XCTAssertNotNil(m, @"Could not initialize model from string");
+    
+    //import
+    XCTAssertEqualObjects(m.identifier, @"12345", @"identifier does not equal '12345'");
+    XCTAssertEqualObjects(m.name, @"TEST", @"name does not equal 'TEST'");
+    
+    //export
+    NSDictionary* dict = [m toDictionary];
+    XCTAssertNotNil(dict, @"toDictionary failed");
+    
+    XCTAssertEqualObjects(dict[@"ID"], m.identifier, @"ID does not equal '12345'");
+    XCTAssertEqualObjects(dict[@"NAME"], m.name, @"NAME does not equal 'TEST'");
 }
 
 -(void)testKeyMapperCaching

--- a/JSONModelDemoTests/UnitTests/TestModels/RenamedPropertyModel.h
+++ b/JSONModelDemoTests/UnitTests/TestModels/RenamedPropertyModel.h
@@ -1,0 +1,16 @@
+//
+//  RenamedPropertyModel.h
+//  JSONModelDemo_iOS
+//
+//  Created by Scott Guelich on 5/21/15.
+//  Copyright (c) 2015. All rights reserved.
+//
+
+#import "JSONModel.h"
+
+@interface RenamedPropertyModel : JSONModel
+
+@property (copy, nonatomic) NSString* identifier;
+@property (copy, nonatomic) NSString* name;
+
+@end

--- a/JSONModelDemoTests/UnitTests/TestModels/RenamedPropertyModel.m
+++ b/JSONModelDemoTests/UnitTests/TestModels/RenamedPropertyModel.m
@@ -1,0 +1,18 @@
+//
+//  RenamedPropertyModel.m
+//  JSONModelDemo_iOS
+//
+//  Created by Scott Guelich on 5/21/15.
+//  Copyright (c) 2015. All rights reserved.
+//
+
+#import "RenamedPropertyModel.h"
+
+@implementation RenamedPropertyModel
+
++ (JSONKeyMapper *)keyMapper {
+    return [JSONKeyMapper mapper:[JSONKeyMapper mapperFromUpperCaseToLowerCase]
+                  withExceptions:@{@"ID": @"identifier"}];
+}
+
+@end

--- a/JSONModelDemo_OSX.xcodeproj/project.pbxproj
+++ b/JSONModelDemo_OSX.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		9CD4258B170222AF00A42AA1 /* MockNSURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CD42588170222AF00A42AA1 /* MockNSURLConnection.m */; };
 		9CD4258C170222AF00A42AA1 /* MTTestSemaphor.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CD4258A170222AF00A42AA1 /* MTTestSemaphor.m */; };
 		9CFDD0A4176E9742007B7DFA /* EnumModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CFDD0A3176E9742007B7DFA /* EnumModel.m */; };
+		D2552E2E1B0E340300B29ADF /* RenamedPropertyModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D2552E2D1B0E340300B29ADF /* RenamedPropertyModel.m */; };
 		D5F918E5172AD99600AC2C8E /* specialPropertyName.json in Resources */ = {isa = PBXBuildFile; fileRef = D5F918E1172AD8CF00AC2C8E /* specialPropertyName.json */; };
 		D5F918EB172ADA3F00AC2C8E /* SpecialPropertyModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D5F918EA172ADA3F00AC2C8E /* SpecialPropertyModel.m */; };
 		D5F918EE172ADAF900AC2C8E /* SpecialPropertyNameTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D5F918ED172ADAF800AC2C8E /* SpecialPropertyNameTests.m */; };
@@ -264,6 +265,8 @@
 		9CD4258A170222AF00A42AA1 /* MTTestSemaphor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MTTestSemaphor.m; path = JSONModelDemoTests/MTTestSemaphor.m; sourceTree = SOURCE_ROOT; };
 		9CFDD0A2176E9742007B7DFA /* EnumModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnumModel.h; sourceTree = "<group>"; };
 		9CFDD0A3176E9742007B7DFA /* EnumModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EnumModel.m; sourceTree = "<group>"; };
+		D2552E2C1B0E340300B29ADF /* RenamedPropertyModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenamedPropertyModel.h; sourceTree = "<group>"; };
+		D2552E2D1B0E340300B29ADF /* RenamedPropertyModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenamedPropertyModel.m; sourceTree = "<group>"; };
 		D5F918E1172AD8CF00AC2C8E /* specialPropertyName.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = specialPropertyName.json; sourceTree = "<group>"; };
 		D5F918E9172ADA3F00AC2C8E /* SpecialPropertyModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecialPropertyModel.h; sourceTree = "<group>"; };
 		D5F918EA172ADA3F00AC2C8E /* SpecialPropertyModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SpecialPropertyModel.m; sourceTree = "<group>"; };
@@ -316,7 +319,6 @@
 			children = (
 				9CD4257D1702220300A42AA1 /* Class */,
 				9C05B3FE168CEB220054215E /* DataFiles */,
-				9C05B420168CEB220054215E /* TestModels */,
 				9C05B3F6168CEB220054215E /* ArrayTests.h */,
 				9C05B3F7168CEB220054215E /* ArrayTests.m */,
 				9C05B3F8168CEB220054215E /* BuiltInConversionsTests.h */,
@@ -418,6 +420,8 @@
 				9C05B438168CEB220054215E /* PostsModel.m */,
 				9C05B439168CEB220054215E /* PrimitivesModel.h */,
 				9C05B43A168CEB220054215E /* PrimitivesModel.m */,
+				D2552E2C1B0E340300B29ADF /* RenamedPropertyModel.h */,
+				D2552E2D1B0E340300B29ADF /* RenamedPropertyModel.m */,
 				9C05B43B168CEB220054215E /* ReposModel.h */,
 				9C05B43C168CEB220054215E /* ReposModel.m */,
 				D5F918E9172ADA3F00AC2C8E /* SpecialPropertyModel.h */,
@@ -641,7 +645,7 @@
 			name = JSONModelDemoTests;
 			productName = JSONModelDemoTests;
 			productReference = 9C05B2A8168CE9600054215E /* JSONModelDemoTests.xctest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		9CC27C8C1689B7BE008B5411 /* JSONModelDemo_OSX */ = {
 			isa = PBXNativeTarget;
@@ -791,6 +795,7 @@
 				9CD4258B170222AF00A42AA1 /* MockNSURLConnection.m in Sources */,
 				9CD4258C170222AF00A42AA1 /* MTTestSemaphor.m in Sources */,
 				9C735D67170B717F00FF96F5 /* JSONAPITests.m in Sources */,
+				D2552E2E1B0E340300B29ADF /* RenamedPropertyModel.m in Sources */,
 				9C735D6D170B7A2D00FF96F5 /* RpcRequestModel.m in Sources */,
 				9C735D73170C048C00FF96F5 /* InitFromWebTests.m in Sources */,
 				9C08C1AF1749750100AA8CC9 /* CopyrightModel.m in Sources */,

--- a/JSONModelDemo_iOS.xcodeproj/project.pbxproj
+++ b/JSONModelDemo_iOS.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4A50001D19C5DCCF00C161A0 /* InitWithDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A50001C19C5DCCF00C161A0 /* InitWithDataTests.m */; };
 		358FD078D3C0D56C77ACD770 /* ExtremeNestingModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 358FDBE28A19497358D1A6DA /* ExtremeNestingModel.m */; };
 		358FD179E0B41C47C67713B5 /* InteractionModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 358FDCB3CFE05DBA0DE27E5F /* InteractionModel.m */; };
 		358FD61804BD21F41035348E /* ExtremeNestingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 358FDBA42551FF88466BD5C3 /* ExtremeNestingTests.m */; };
 		358FD640BFEAB00349FBBA4A /* DrugModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 358FD25356988AC33EA6A935 /* DrugModel.m */; };
+		4A50001D19C5DCCF00C161A0 /* InitWithDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A50001C19C5DCCF00C161A0 /* InitWithDataTests.m */; };
 		69286BDA17FA280900D1BA81 /* nestedDataWithDictionaryError.json in Resources */ = {isa = PBXBuildFile; fileRef = 69286BD917FA280900D1BA81 /* nestedDataWithDictionaryError.json */; };
 		69286BDB17FA280900D1BA81 /* nestedDataWithDictionaryError.json in Resources */ = {isa = PBXBuildFile; fileRef = 69286BD917FA280900D1BA81 /* nestedDataWithDictionaryError.json */; };
 		697852FD17D934B5006BFCD0 /* nestedDataWithTypeMismatchOnImages.json in Resources */ = {isa = PBXBuildFile; fileRef = 697852FC17D934B5006BFCD0 /* nestedDataWithTypeMismatchOnImages.json */; };
@@ -142,6 +142,7 @@
 		9CFDD0D9176E977C007B7DFA /* ReposModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CFDD0C5176E977C007B7DFA /* ReposModel.m */; };
 		9CFDD0DA176E977C007B7DFA /* RpcRequestModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CFDD0C7176E977C007B7DFA /* RpcRequestModel.m */; };
 		9CFDD0DB176E977C007B7DFA /* SpecialPropertyModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CFDD0C9176E977C007B7DFA /* SpecialPropertyModel.m */; };
+		D2552E2B1B0E33F700B29ADF /* RenamedPropertyModel.m in Sources */ = {isa = PBXBuildFile; fileRef = D2552E2A1B0E33F700B29ADF /* RenamedPropertyModel.m */; };
 		D66F5792A312B021F52F7BFF /* ModelForUpperCaseMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = D66F58FBC6313C65C9357A2F /* ModelForUpperCaseMapper.m */; };
 /* End PBXBuildFile section */
 
@@ -156,7 +157,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		4A50001C19C5DCCF00C161A0 /* InitWithDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InitWithDataTests.m; sourceTree = "<group>"; };
 		358FD25356988AC33EA6A935 /* DrugModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DrugModel.m; sourceTree = "<group>"; };
 		358FD7AD55FD213CBAAB460F /* ExtremeNestingModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtremeNestingModel.h; sourceTree = "<group>"; };
 		358FD807C3E86F5DC4058645 /* ExtremeNestingTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtremeNestingTests.h; sourceTree = "<group>"; };
@@ -165,6 +165,7 @@
 		358FDBE28A19497358D1A6DA /* ExtremeNestingModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExtremeNestingModel.m; sourceTree = "<group>"; };
 		358FDCB3CFE05DBA0DE27E5F /* InteractionModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InteractionModel.m; sourceTree = "<group>"; };
 		358FDED5E028AA00D3E6564D /* InteractionModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InteractionModel.h; sourceTree = "<group>"; };
+		4A50001C19C5DCCF00C161A0 /* InitWithDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InitWithDataTests.m; sourceTree = "<group>"; };
 		69286BD917FA280900D1BA81 /* nestedDataWithDictionaryError.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = nestedDataWithDictionaryError.json; sourceTree = "<group>"; };
 		697852FC17D934B5006BFCD0 /* nestedDataWithTypeMismatchOnImages.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = nestedDataWithTypeMismatchOnImages.json; sourceTree = "<group>"; };
 		697852FE17D93546006BFCD0 /* nestedDataWithTypeMismatchOnImagesObject.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = nestedDataWithTypeMismatchOnImagesObject.json; sourceTree = "<group>"; };
@@ -339,6 +340,8 @@
 		9CFDD0C7176E977C007B7DFA /* RpcRequestModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RpcRequestModel.m; sourceTree = "<group>"; };
 		9CFDD0C8176E977C007B7DFA /* SpecialPropertyModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecialPropertyModel.h; sourceTree = "<group>"; };
 		9CFDD0C9176E977C007B7DFA /* SpecialPropertyModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SpecialPropertyModel.m; sourceTree = "<group>"; };
+		D2552E291B0E33F700B29ADF /* RenamedPropertyModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenamedPropertyModel.h; sourceTree = "<group>"; };
+		D2552E2A1B0E33F700B29ADF /* RenamedPropertyModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenamedPropertyModel.m; sourceTree = "<group>"; };
 		D66F555A1EB344B7A5FF0D85 /* ModelForUpperCaseMapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelForUpperCaseMapper.h; sourceTree = "<group>"; };
 		D66F58FBC6313C65C9357A2F /* ModelForUpperCaseMapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ModelForUpperCaseMapper.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -761,6 +764,8 @@
 				9CFDD0C1176E977C007B7DFA /* PostsModel.m */,
 				9CFDD0C2176E977C007B7DFA /* PrimitivesModel.h */,
 				9CFDD0C3176E977C007B7DFA /* PrimitivesModel.m */,
+				D2552E291B0E33F700B29ADF /* RenamedPropertyModel.h */,
+				D2552E2A1B0E33F700B29ADF /* RenamedPropertyModel.m */,
 				9CFDD0C4176E977C007B7DFA /* ReposModel.h */,
 				9CFDD0C5176E977C007B7DFA /* ReposModel.m */,
 				9CFDD0C6176E977C007B7DFA /* RpcRequestModel.h */,
@@ -988,6 +993,7 @@
 				9CFDD0CF176E977C007B7DFA /* GitHubKeyMapRepoModelDict.m in Sources */,
 				9CFDD0D0176E977C007B7DFA /* GitHubRepoModel.m in Sources */,
 				9CFDD0D1176E977C007B7DFA /* GitHubRepoModelForUSMapper.m in Sources */,
+				D2552E2B1B0E33F700B29ADF /* RenamedPropertyModel.m in Sources */,
 				9CFDD0D2176E977C007B7DFA /* ImageModel.m in Sources */,
 				9CFDD0D3176E977C007B7DFA /* JSONTypesModel.m in Sources */,
 				9CFDD0D4176E977C007B7DFA /* NestedModel.m in Sources */,

--- a/README.md
+++ b/README.md
@@ -323,6 +323,42 @@ Examples
 </tr>
 </table>
 
+#### Map automatically with exceptions
+<table>
+<tr>
+<td valign="top">
+<pre>
+{
+  "oid": 104,
+  "order_product" : @"Product#1",
+  "order_price" : 12.95
+}
+</pre>
+</td>
+<td valign="top">
+<pre>
+@interface OrderModel : JSONModel
+
+@property (assign, nonatomic) int orderId;
+@property (assign, nonatomic) float orderPrice;
+@property (strong, nonatomic) NSString* orderProduct;
+
+@end
+
+@implementation OrderModel
+
++(JSONKeyMapper*)keyMapper
+{
+  return <b>[JSONKeyMapper mapper:[JSONKeyMapper mapperFromUnderscoreCaseToCamelCase]
+                withExceptions:@{ @"oid": @"orderId" }];</b>
+}
+
+@end
+</pre>
+</td>
+</tr>
+</table>
+
 #### Optional properties (i.e. can be missing or null)
 <table>
 <tr>


### PR DESCRIPTION
This adds a `mapper:withExceptions:` method to JSONKeyMapper, which enables us to use the built-in key mappers (uppercase, camelcase, or others we define) but still override individual property names. 

Without this, we're forced to use a dictionary for all names even if most follow a simple mapping rule with only one or two exceptions.