### PR TITLE
Allow specifying an NSArray's protocol type in implementation method

### DIFF
--- a/JSONModel/JSONModel/JSONModel.h
+++ b/JSONModel/JSONModel/JSONModel.h
@@ -324,6 +324,20 @@ lastPathComponent], __LINE__, [NSString stringWithFormat:(s), ##__VA_ARGS__] )
 +(BOOL)propertyIsIgnored:(NSString*)propertyName;
 
 /**
+ * Indicates the protocol name for an array property.
+ * Rather than using:
+ *     @property (strong) NSArray<MyType>* things;
+ * You can implement protocolForArrayProperty: and keep your property 
+ * defined like:
+ *     @property (strong) NSArray* things;
+ * @param propertyName the name of the property
+ * @return an NSString result indicating the name of the protocol/class
+ * that should be contained in this array property. Return nil to indicate
+ * no contained protocol.
+ */
++(NSString*)protocolForArrayProperty:(NSString *)propertyName;
+
+/**
  * Merges values from the given dictionary into the model instance.
  * @param dict dictionary with values
  * @param useKeyMapping if YES the method will use the model's key mapper and the global key mapper, if NO 

--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -676,6 +676,11 @@ static JSONKeyMapper* globalKeyMapper = nil;
             if([[self class] propertyIsIgnored:nsPropertyName]){
                 p = nil;
             }
+
+            NSString* customProtocol = [[self class] protocolForArrayProperty:nsPropertyName];
+            if (customProtocol) {
+                p.protocol = customProtocol;
+            }
             
             //few cases where JSONModel will ignore properties automatically
             if ([propertyType isEqualToString:@"Block"]) {
@@ -1268,6 +1273,11 @@ static JSONKeyMapper* globalKeyMapper = nil;
 +(BOOL)propertyIsIgnored:(NSString *)propertyName
 {
     return NO;
+}
+
++(NSString*)protocolForArrayProperty:(NSString *)propertyName
+{
+    return nil;
 }
 
 #pragma mark - working with incomplete models

--- a/JSONModelDemoTests/UnitTests/ArrayTests.m
+++ b/JSONModelDemoTests/UnitTests/ArrayTests.m
@@ -13,6 +13,7 @@
 @implementation ArrayTests
 {
     ReposModel* repos;
+    ReposProtocolArrayModel* reposProtocolArray;
 }
 
 -(void)setUp
@@ -28,6 +29,9 @@
     repos = [[ReposModel alloc] initWithString:jsonContents error:&err];
     XCTAssertNil(err, @"%@", [err localizedDescription]);
     
+    reposProtocolArray = [[ReposProtocolArrayModel alloc] initWithString:jsonContents error:&err];
+    XCTAssertNil(err, @"%@", [err localizedDescription]);
+    
     XCTAssertNotNil(repos, @"Could not load the test data file.");
 
 }
@@ -36,11 +40,15 @@
 {
     XCTAssertTrue([repos.repositories isMemberOfClass:[JSONModelArray class]], @".properties is not a JSONModelArray");
     XCTAssertEqualObjects([[repos.repositories[0] class] description], @"GitHubRepoModel", @".properties[0] is not a GitHubRepoModel");
+    
+    XCTAssertTrue([reposProtocolArray.repositories isMemberOfClass:[JSONModelArray class]], @".properties is not a JSONModelArray");
+    XCTAssertEqualObjects([[reposProtocolArray.repositories[0] class] description], @"GitHubRepoModel", @".properties[0] is not a GitHubRepoModel");
 }
 
 -(void)testCount
 {
     XCTAssertEqualObjects(@(repos.repositories.count), @100, @"wrong count");
+    XCTAssertEqualObjects(@(reposProtocolArray.repositories.count), @100, @"wrong count");
 }
 
 -(void)testFastEnumeration
@@ -48,6 +56,10 @@
 	for (GitHubRepoModel *m in repos.repositories) {
 		XCTAssertNoThrow([m created], @"should not throw exception");
 	}
+    
+    for (GitHubRepoModel *m in reposProtocolArray.repositories) {
+        XCTAssertNoThrow([m created], @"should not throw exception");
+    }
 }
 
 -(void)testReadArray
@@ -65,6 +77,7 @@
 -(void)testFirstObject
 {
     XCTAssertEqualObjects([[repos.repositories.firstObject class] description], @"GitHubRepoModel", @"wrong class");
+    XCTAssertEqualObjects([[reposProtocolArray.repositories.firstObject class] description], @"GitHubRepoModel", @"wrong class");
 }
 
 /*
@@ -74,6 +87,9 @@
 {
     NSDictionary* dict = [repos toDictionary];
     XCTAssertNotNil(dict, @"Could not convert ReposModel back to an NSDictionary");
+    
+    NSDictionary* dict2 = [reposProtocolArray toDictionary];
+    XCTAssertNotNil(dict2, @"Could not convert ReposProtocolArrayModel back to an NSDictionary");
 }
 
 /*
@@ -83,6 +99,9 @@
 {
     NSString* string = [repos toJSONString];
     XCTAssertNotNil(string, @"Could not convert ReposModel back to a string");
+    
+    NSString* string2 = [reposProtocolArray toJSONString];
+    XCTAssertNotNil(string2, @"Could not convert ReposProtocolArrayModel back to a string");
 }
 
 @end

--- a/JSONModelDemoTests/UnitTests/TestModels/ReposModel.h
+++ b/JSONModelDemoTests/UnitTests/TestModels/ReposModel.h
@@ -14,3 +14,9 @@
 @property (strong, nonatomic) NSMutableArray<ConvertOnDemand, GitHubRepoModel>* repositories;
 
 @end
+
+@interface ReposProtocolArrayModel : JSONModel
+
+@property (strong, nonatomic) NSMutableArray<ConvertOnDemand>* repositories;
+
+@end

--- a/JSONModelDemoTests/UnitTests/TestModels/ReposModel.m
+++ b/JSONModelDemoTests/UnitTests/TestModels/ReposModel.m
@@ -11,3 +11,16 @@
 @implementation ReposModel
 
 @end
+
+
+@implementation ReposProtocolArrayModel
+
++(NSString*)protocolForArrayProperty:(NSString *)propertyName
+{
+    if ([propertyName isEqualToString:@"repositories"]) {
+        return NSStringFromClass(GitHubRepoModel.class);
+    }
+    return nil;
+}
+
+@end


### PR DESCRIPTION
Rather than declaring the contained type of an NSArray property like:

```objc
@property (strong) NSArray<MyType>* things;
```

You can alternatively implement the `+protocolForArrayProperty:` method:

```objc
+ (NSString*)protocolForArrayProperty:(NSString*)propertyName
{
    if ([propertyName isEqualToString:NSStringFromSelector(@selector(things))]) {
        return NSStringFromClass(MyType.class);
    }
    return [super protocolForArrayProperty:propertyName];
}
```

We use JSONModel to define classes for our public API. I would prefer to not leak JSONModel implementation details through our API's public surface area. Non-standard use of protocols is one of those leaks. By allowing you to alternatively choose the container type for NSArray property in the implementation of your class, we can hide these JSONModel details form our API users.