### PR TITLE
Fixing very unsafe code

### DIFF
--- a/JSONModel/JSONModelTransformations/JSONKeyMapper.m
+++ b/JSONModel/JSONModelTransformations/JSONKeyMapper.m
@@ -70,27 +70,39 @@
     return self;
 }
 
--(instancetype)initWithDictionary:(NSDictionary*)map
+-(instancetype)initWithDictionary:(NSDictionary *)map
 {
     self = [super init];
     if (self) {
-        //initialize
-
-        NSMutableDictionary* userToModelMap = [NSMutableDictionary dictionaryWithDictionary: map];
-        NSMutableDictionary* userToJSONMap  = [NSMutableDictionary dictionaryWithObjects:map.allKeys forKeys:map.allValues];
         
-        _JSONToModelKeyBlock = ^NSString*(NSString* keyName) {
-            NSString* result = [userToModelMap valueForKeyPath: keyName];
-            return result?result:keyName;
+        NSDictionary *userToModelMap = [map copy];
+        NSDictionary *userToJSONMap  = [self swapKeysAndValuesInDictionary:map];
+        
+        _JSONToModelKeyBlock = ^NSString *(NSString *keyName) {
+            NSString *result = [userToModelMap valueForKeyPath:keyName];
+            return result ? result : keyName;
         };
         
-        _modelToJSONKeyBlock = ^NSString*(NSString* keyName) {
-            NSString* result = [userToJSONMap valueForKeyPath: keyName];
-            return result?result:keyName;
+        _modelToJSONKeyBlock = ^NSString *(NSString *keyName) {
+            NSString *result = [userToJSONMap valueForKeyPath:keyName];
+            return result ? result : keyName;
         };
     }
     
     return self;
+}
+
+- (NSDictionary *)swapKeysAndValuesInDictionary:(NSDictionary *)dictionary
+{
+    NSMutableDictionary *swapped = [NSMutableDictionary new];
+    
+    [dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
+        NSAssert([value isKindOfClass:[NSString class]], @"Expect keys and values to be NSString");
+        NSAssert([key isKindOfClass:[NSString class]], @"Expect keys and values to be NSString");
+        swapped[value] = key;
+    }];
+    
+    return swapped;
 }
 
 -(NSString*)convertValue:(NSString*)value isImportingToModel:(BOOL)importing


### PR DESCRIPTION
I found a very shocking line in this code. 
```
 NSMutableDictionary* userToJSONMap  = [NSMutableDictionary dictionaryWithObjects:map.allKeys forKeys:map.allValues];
```

Reading the documentation it is clear that this was working by pure luck:
```
@property(readonly, copy) NSArray *allKeys
Description	
A new array containing the dictionary’s keys, or an empty array if the dictionary has no entries (read-only)
The order of the elements in the array is not defined.

@property(readonly, copy) NSArray *allValues
Description	
A new array containing the dictionary’s values, or an empty array if the dictionary has no entries (read-only)
The order of the values in the array isn’t defined.
```