### PR TITLE
Updated iOS deplyoment target

### DIFF
--- a/JSONModel.podspec
+++ b/JSONModel.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/icanzilb/JSONModel.git", :tag => "1.1" }
 
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.7'
 
   s.source_files = 'JSONModel/**/*.{m,h}'


### PR DESCRIPTION
This will solve an issue with AFNetworking integration using it as a dependency on a third library.
For example, I created a library that depends on JSONModel v1.1.0 and AFNetworking v2.6.0 but it doesn't compile if JSONModel declare an iOS compatibility as iOS >= 5.0