### PR TITLE
Keep responseData in JSONModelError

### DIFF
--- a/JSONModel/JSONModel/JSONModelError.h
+++ b/JSONModel/JSONModel/JSONModelError.h
@@ -62,6 +62,8 @@ extern NSString* const kJSONModelKeyPath;
 
 @property (strong, nonatomic) NSHTTPURLResponse* httpResponse;
 
+@property (strong, nonatomic) NSData* responseData;
+
 /**
  * Creates a JSONModelError instance with code kJSONModelErrorInvalidData = 1
  */

--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.m
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.m
@@ -310,8 +310,10 @@ static NSString* requestContentType = nil;
         }
         //step 4.5: cover an edge case in which meaningful content is return along an error HTTP status code
         else if (error && responseData && jsonObject==nil) {
-            //try to get the JSON object, while preserving the origianl error object
+            //try to get the JSON object, while preserving the original error object
             jsonObject = [NSJSONSerialization JSONObjectWithData:responseData options:kNilOptions error:nil];
+            //keep responseData just in case it contains error information
+            error.responseData = responseData;
         }
         
         //step 5: invoke the complete block


### PR DESCRIPTION
I have a situation where my API returns error information (some text) in the response.

To be able to retrieve that, I added the `responseData` in `JSONModelError`. That way I can do this:

    if (error) {
        NSString* errorInfo = [[NSString alloc] initWithData:error.responseData 
                                                    encoding:NSUTF8StringEncoding];
        ...
    }