### PR TITLE
Add deployment target to support watchOS 2

### DIFF
--- a/JSONModel.podspec
+++ b/JSONModel.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
+  s.watchos.deployment_target = '2.0'
 
   s.source_files = 'JSONModel/**/*.{m,h}'
   s.public_header_files = 'JSONModel/**/*.h'


### PR DESCRIPTION
Allows JSONModel to be included in via CocoaPods into a watchOS 2 project.