### PR TITLE
Allow custom setters for multiple types

### DIFF
--- a/JSONModel/JSONModel/JSONModelClassProperty.h
+++ b/JSONModel/JSONModel/JSONModelClassProperty.h
@@ -22,7 +22,6 @@ enum kCustomizationTypes {
     kNo
     };
 
-typedef enum kCustomizationTypes PropertySetterType;
 typedef enum kCustomizationTypes PropertyGetterType;
 
 /**
@@ -68,10 +67,7 @@ typedef enum kCustomizationTypes PropertyGetterType;
 /** a custom getter for this property, found in the owning model */
 @property (assign, nonatomic) SEL customGetter;
 
-/** The status of property setter introspection in a model */
-@property (assign, nonatomic) PropertySetterType setterType;
-
-/** a custom setter for this property, found in the owning model */
-@property (assign, nonatomic) SEL customSetter;
+/** custom setters for this property, found in the owning model */
+@property (strong, nonatomic) NSMutableDictionary<NSString *, id> *customSetters;
 
 @end

--- a/JSONModel/JSONModel/JSONModelClassProperty.m
+++ b/JSONModel/JSONModel/JSONModelClassProperty.m
@@ -28,8 +28,20 @@
     if (self.isMutable) [properties addObject:@"Mutable"];
     if (self.convertsOnDemand) [properties addObject:@"ConvertOnDemand"];
     if (self.isStandardJSONType) [properties addObject:@"Standard JSON type"];
-    if (self.customSetter) [properties addObject:[NSString stringWithFormat: @"Setter = %@", NSStringFromSelector(self.customSetter)]];
     if (self.customGetter) [properties addObject:[NSString stringWithFormat: @"Getter = %@", NSStringFromSelector(self.customGetter)]];
+
+    if (self.customSetters)
+    {
+        NSMutableArray *setters = [NSMutableArray array];
+
+        for (id obj in self.customSetters.allValues)
+        {
+            if (obj != [NSNull null])
+                [setters addObject:obj];
+        }
+
+        [properties addObject:[NSString stringWithFormat: @"Setters = [%@]", [setters componentsJoinedByString:@", "]]];
+    }
     
     NSString* propertiesString = @"";
     if (properties.count>0) {


### PR DESCRIPTION
The existing behavior is flawed in that the first custom setter used would always be used, even for values of a different type. This new behavior caches the setter on a per-type basis.

Resolves #345